### PR TITLE
Handle both rmd160 and ripemd16 cryptographic hashes

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -9,7 +9,11 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 var createHash = require('create-hash');
 function ripemd160(buffer) {
-  return createHash('rmd160').update(buffer).digest('hex');
+  try {
+    return createHash('rmd160').update(buffer).digest('hex');
+  } catch(e) {
+    return createHash('ripemd160').update(buffer).digest('hex');
+  }
 }
 function sha1(buffer) {
   return createHash('sha1').update(buffer).digest('hex');


### PR DESCRIPTION
Some of our application require a patch for zencashjs which would no longer be required.